### PR TITLE
Add napsap coding test with example solutions

### DIFF
--- a/napsap/README.md
+++ b/napsap/README.md
@@ -1,0 +1,22 @@
+# Napsap Coding Test
+
+This directory contains a simple coding test around the **napsap** problem (a variant of the classic knapsack problem).
+
+## Problem Statement
+
+Given a list of items where each item has a weight and a value, and given a maximum capacity, determine the maximum total value of items that can be placed into the napsap without exceeding the capacity.
+
+### Input
+- `capacity`: positive integer specifying the maximum weight the napsap can hold.
+- `items`: list of `(weight, value)` pairs.
+
+### Output
+- Maximum value achievable within the given capacity.
+
+## Solutions
+Three example solutions are provided:
+1. **Brute force** (`solution_bruteforce.py`)
+2. **Dynamic programming with memoization** (`solution_memoization.py`)
+3. **Bottom-up dynamic programming** (`solution_bottomup.py`)
+
+Run any script with Python 3 to see it in action.

--- a/napsap/solution_bottomup.py
+++ b/napsap/solution_bottomup.py
@@ -1,0 +1,23 @@
+from typing import List, Tuple
+
+Item = Tuple[int, int]
+
+def knapsack_bottomup(capacity: int, items: List[Item]) -> int:
+    """Bottom-up dynamic programming solution."""
+    n = len(items)
+    dp = [[0] * (capacity + 1) for _ in range(n + 1)]
+
+    for i in range(1, n + 1):
+        weight, value = items[i - 1]
+        for w in range(capacity + 1):
+            if weight <= w:
+                dp[i][w] = max(dp[i - 1][w], value + dp[i - 1][w - weight])
+            else:
+                dp[i][w] = dp[i - 1][w]
+
+    return dp[n][capacity]
+
+if __name__ == "__main__":
+    sample_items = [(2, 3), (1, 2), (3, 4), (2, 2)]
+    cap = 5
+    print(knapsack_bottomup(cap, sample_items))

--- a/napsap/solution_bruteforce.py
+++ b/napsap/solution_bruteforce.py
@@ -1,0 +1,24 @@
+from typing import List, Tuple
+
+Item = Tuple[int, int]  # (weight, value)
+
+def knapsack_bruteforce(capacity: int, items: List[Item]) -> int:
+    """Brute force solution exploring all subsets."""
+    n = len(items)
+    best = 0
+    for mask in range(1 << n):
+        total_w = 0
+        total_v = 0
+        for i in range(n):
+            if mask & (1 << i):
+                w, v = items[i]
+                total_w += w
+                total_v += v
+        if total_w <= capacity and total_v > best:
+            best = total_v
+    return best
+
+if __name__ == "__main__":
+    sample_items = [(2, 3), (1, 2), (3, 4), (2, 2)]
+    cap = 5
+    print(knapsack_bruteforce(cap, sample_items))

--- a/napsap/solution_memoization.py
+++ b/napsap/solution_memoization.py
@@ -1,0 +1,26 @@
+from functools import lru_cache
+from typing import List, Tuple
+
+Item = Tuple[int, int]
+
+def knapsack_memoization(capacity: int, items: List[Item]) -> int:
+    """Top-down dynamic programming with memoization."""
+    n = len(items)
+
+    @lru_cache(maxsize=None)
+    def dp(i: int, remaining: int) -> int:
+        if i == n or remaining <= 0:
+            return 0
+        weight, value = items[i]
+        skip = dp(i + 1, remaining)
+        take = 0
+        if weight <= remaining:
+            take = value + dp(i + 1, remaining - weight)
+        return max(take, skip)
+
+    return dp(0, capacity)
+
+if __name__ == "__main__":
+    sample_items = [(2, 3), (1, 2), (3, 4), (2, 2)]
+    cap = 5
+    print(knapsack_memoization(cap, sample_items))


### PR DESCRIPTION
## Summary
- add `napsap` folder describing a napsap (knapsack) coding test
- provide three Python solutions: brute force, memoization, bottom-up DP

## Testing
- `pytest -q`
- `python3 napsap/solution_bruteforce.py`
- `python3 napsap/solution_memoization.py`
- `python3 napsap/solution_bottomup.py`

------
https://chatgpt.com/codex/tasks/task_e_683fcf538104832782aa35bcb8bea583